### PR TITLE
Simplify a few things.

### DIFF
--- a/bigcommerce/entities.go
+++ b/bigcommerce/entities.go
@@ -1,8 +1,8 @@
 package bigcommerce
 
-// Count is a generic object used for returning resource counts.
-type Count struct {
-	Count *uint32 `json:"count"`
+// count is a generic object used for returning resource counts.
+type count struct {
+	Count int `json:"count"`
 }
 
 // AddressEntities defines a list of the AddressEntity object.

--- a/bigcommerce/order_shipping_addresses.go
+++ b/bigcommerce/order_shipping_addresses.go
@@ -8,9 +8,6 @@ import (
 	"github.com/dghubble/sling"
 )
 
-// OrderShippingAddresses defines a list of the OrderShippingAddress object.
-type OrderShippingAddresses []OrderShippingAddress
-
 // Order describes the product resource
 type OrderShippingAddress struct {
 	AddressEntity
@@ -38,28 +35,28 @@ type OrderShippingAddressListParams struct {
 }
 
 // List returns a list of OrderShippingAddresses matching the given OrderShippingAddressListParams.
-func (s *OrderShippingAddressService) List(ctx context.Context, orderID int32, params *OrderShippingAddressListParams) (*OrderShippingAddresses, *http.Response, error) {
-	orderShippingAddresses := new(OrderShippingAddresses)
+func (s *OrderShippingAddressService) List(ctx context.Context, orderID int32, params *OrderShippingAddressListParams) ([]OrderShippingAddress, *http.Response, error) {
+	var osa []OrderShippingAddress
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses", orderID)).QueryStruct(params), s.httpClient, orderShippingAddresses, apiError)
-	return orderShippingAddresses, resp, relevantError(err, *apiError)
+	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses", orderID)).QueryStruct(params), s.httpClient, &osa, apiError)
+	return osa, resp, relevantError(err, *apiError)
 }
 
 // Count returns an OrderShippingAddressCount for OrderShippingAddresses that matches the given OrderShippingAddressListParams.
-func (s *OrderShippingAddressService) Count(ctx context.Context, orderID int32, params *OrderShippingAddressListParams) (*Count, *http.Response, error) {
-	count := new(Count)
+func (s *OrderShippingAddressService) Count(ctx context.Context, orderID int32, params *OrderShippingAddressListParams) (int, *http.Response, error) {
+	var cnt count
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses/count", orderID)).QueryStruct(params), s.httpClient, count, apiError)
-	return count, resp, relevantError(err, *apiError)
+	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses/count", orderID)).QueryStruct(params), s.httpClient, &cnt, apiError)
+	return cnt.Count, resp, relevantError(err, *apiError)
 }
 
 // Show returns the requested OrderShippingAddress.
 func (s *OrderShippingAddressService) Show(ctx context.Context, orderID int32, id int32) (*OrderShippingAddress, *http.Response, error) {
-	orderShippingAddress := new(OrderShippingAddress)
+	osa := new(OrderShippingAddress)
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses/%d", orderID, id)), s.httpClient, orderShippingAddress, apiError)
-	return orderShippingAddress, resp, relevantError(err, *apiError)
+	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses/%d", orderID, id)), s.httpClient, osa, apiError)
+	return osa, resp, relevantError(err, *apiError)
 }

--- a/bigcommerce/order_shipping_addresses_test.go
+++ b/bigcommerce/order_shipping_addresses_test.go
@@ -20,7 +20,7 @@ func TestOrderShippingAddressService_List(t *testing.T) {
 		fmt.Fprintf(w, `[{ "id": 123 }]`)
 	})
 
-	expected := &OrderShippingAddresses{
+	expected := []OrderShippingAddress{
 		{ID: 123},
 	}
 	client := NewClient(httpClient, &ClientConfig{

--- a/bigcommerce/order_statuses.go
+++ b/bigcommerce/order_statuses.go
@@ -8,9 +8,6 @@ import (
 	"github.com/dghubble/sling"
 )
 
-// OrderStatuses defines a list of the OrderStatus object.
-type OrderStatuses []OrderStatus
-
 // OrderStatus describes the product resource
 type OrderStatus struct {
 	ID    int32  `json:"id"`
@@ -38,12 +35,12 @@ type OrderStatusListParams struct {
 }
 
 // List returns a list of Products matching the given ProductListParams.
-func (s *OrderStatusService) List(ctx context.Context, params *OrderStatusListParams) (*OrderStatuses, *http.Response, error) {
-	orderStatuses := new(OrderStatuses)
+func (s *OrderStatusService) List(ctx context.Context, params *OrderStatusListParams) ([]OrderStatus, *http.Response, error) {
+	var os []OrderStatus
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().QueryStruct(params), s.httpClient, orderStatuses, apiError)
-	return orderStatuses, resp, relevantError(err, *apiError)
+	resp, err := performRequest(ctx, s.sling.New().QueryStruct(params), s.httpClient, &os, apiError)
+	return os, resp, relevantError(err, *apiError)
 }
 
 // Show returns the requested OrderStatus.

--- a/bigcommerce/order_statuses_test.go
+++ b/bigcommerce/order_statuses_test.go
@@ -20,7 +20,7 @@ func TestOrderStatusService_List(t *testing.T) {
 		fmt.Fprintf(w, `[{ "id": 123 }]`)
 	})
 
-	expected := &OrderStatuses{
+	expected := []OrderStatus{
 		{ID: 123},
 	}
 	client := NewClient(httpClient, &ClientConfig{

--- a/bigcommerce/orders.go
+++ b/bigcommerce/orders.go
@@ -8,9 +8,6 @@ import (
 	"github.com/dghubble/sling"
 )
 
-// Orders defines a list of the Order object.
-type Orders []Order
-
 // Order describes the product resource
 type Order struct {
 	ID                   int32         `json:"id"`
@@ -77,21 +74,21 @@ type OrderListParams struct {
 }
 
 // List returns a list of Orders matching the given OrderListParams.
-func (s *OrderService) List(ctx context.Context, params *OrderListParams) (*Orders, *http.Response, error) {
-	orders := new(Orders)
+func (s *OrderService) List(ctx context.Context, params *OrderListParams) ([]Order, *http.Response, error) {
+	var orders []Order
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().QueryStruct(params), s.httpClient, orders, apiError)
+	resp, err := performRequest(ctx, s.sling.New().QueryStruct(params), s.httpClient, &orders, apiError)
 	return orders, resp, relevantError(err, *apiError)
 }
 
 // Count returns an OrderCount for Orders that matches the given OrderListParams.
-func (s *OrderService) Count(ctx context.Context, params *OrderListParams) (*Count, *http.Response, error) {
-	count := new(Count)
+func (s *OrderService) Count(ctx context.Context, params *OrderListParams) (int, *http.Response, error) {
+	var count count
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.Get("count").QueryStruct(params), s.httpClient, count, apiError)
-	return count, resp, relevantError(err, *apiError)
+	resp, err := performRequest(ctx, s.sling.Get("count").QueryStruct(params), s.httpClient, &count, apiError)
+	return count.Count, resp, relevantError(err, *apiError)
 }
 
 // Show returns the requested Order.
@@ -102,9 +99,6 @@ func (s *OrderService) Show(ctx context.Context, id int32) (*Order, *http.Respon
 	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d", id)), s.httpClient, order, apiError)
 	return order, resp, relevantError(err, *apiError)
 }
-
-// OrderProducts defines a list of the OrderProduct object.
-type OrderProducts []OrderProduct
 
 // OrderProduct defines a product to be included in the OrderBody.
 // Regular Products require: ProductID and Quantity
@@ -123,7 +117,7 @@ type OrderBody struct {
 	CustomerID         *uint32         `json:"customer_id"`
 	StatusID           *uint32         `json:"status_id"`
 	BillingAddress     AddressEntity   `json:"billing_address"`
-	Products           OrderProducts   `json:"products"`
+	Products           []OrderProduct  `json:"products"`
 	ShippingCostIncTax float32         `json:"shipping_cost_inc_tax,omitempty"`
 	ShippingCostExTax  float32         `json:"shipping_cost_ex_tax,omitempty"`
 	HandlingCostIncTax float32         `json:"handling_cost_inc_tax,omitempty"`

--- a/bigcommerce/orders_test.go
+++ b/bigcommerce/orders_test.go
@@ -20,7 +20,7 @@ func TestOrderService_List(t *testing.T) {
 		fmt.Fprintf(w, `[{ "id": 123 }]`)
 	})
 
-	expected := &Orders{
+	expected := []Order{
 		{ID: 123},
 	}
 	client := NewClient(httpClient, &ClientConfig{
@@ -47,10 +47,7 @@ func TestOrderService_Count(t *testing.T) {
 		fmt.Fprintf(w, `{ "count": 12 }`)
 	})
 
-	num := uint32(12)
-	expected := &Count{
-		Count: &num,
-	}
+	expected := 12
 	client := NewClient(httpClient, &ClientConfig{
 		Endpoint: "https://example.com",
 		UserName: "go-bigcommerce",
@@ -117,7 +114,7 @@ func TestOrderService_New(t *testing.T) {
 			Phone:       "12345678",
 			Email:       "example@example.com",
 		},
-		Products: OrderProducts{
+		Products: []OrderProduct{
 			{ProductID: 1, Quantity: 1},
 			{ProductID: 2, Quantity: 1},
 		},

--- a/bigcommerce/product_custom_fields.go
+++ b/bigcommerce/product_custom_fields.go
@@ -8,9 +8,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ProductCustomFields defines a list of the ProductCustomField object.
-type ProductCustomFields []ProductCustomField
-
 // ProductCustomField describes the product custom field resource
 type ProductCustomField struct {
 	ID        int32  `json:"id"`
@@ -39,11 +36,11 @@ type ProductCustomFieldListParams struct {
 }
 
 // List returns a list of ProductCustomFields matching the given ProductCustomFieldListParams.
-func (s *ProductCustomFieldService) List(ctx context.Context, productID int32, params *ProductCustomFieldListParams) (*ProductCustomFields, *http.Response, error) {
-	customFields := new(ProductCustomFields)
+func (s *ProductCustomFieldService) List(ctx context.Context, productID int32, params *ProductCustomFieldListParams) ([]ProductCustomField, *http.Response, error) {
+	var customFields []ProductCustomField
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/custom_fields", productID)).QueryStruct(params), s.httpClient, customFields, apiError)
+	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/custom_fields", productID)).QueryStruct(params), s.httpClient, &customFields, apiError)
 	return customFields, resp, relevantError(err, *apiError)
 }
 

--- a/bigcommerce/product_custom_fields_test.go
+++ b/bigcommerce/product_custom_fields_test.go
@@ -20,7 +20,7 @@ func TestProductCustomFieldService_List(t *testing.T) {
 		fmt.Fprintf(w, `[{ "id": 123 }]`)
 	})
 
-	expected := &ProductCustomFields{
+	expected := []ProductCustomField{
 		{ID: 123},
 	}
 	client := NewClient(httpClient, &ClientConfig{

--- a/bigcommerce/products.go
+++ b/bigcommerce/products.go
@@ -8,9 +8,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Products defines a list of the Product object.
-type Products []Product
-
 // Product describes the product resource
 type Product struct {
 	ID             int32              `json:"id"`
@@ -61,12 +58,12 @@ type ProductListParams struct {
 }
 
 // List returns a list of Products matching the given ProductListParams.
-func (s *ProductService) List(ctx context.Context, params *ProductListParams) (*Products, *http.Response, error) {
-	products := new(Products)
-	apiError := new(APIError)
+func (s *ProductService) List(ctx context.Context, params *ProductListParams) ([]Product, *http.Response, error) {
+	var products []Product
+	var apiError APIError
 
-	resp, err := performRequest(ctx, s.sling.New().QueryStruct(params), s.httpClient, products, apiError) //.Receive(products, apiError)
-	return products, resp, relevantError(err, *apiError)
+	resp, err := performRequest(ctx, s.sling.New().QueryStruct(params), s.httpClient, &products, apiError) //.Receive(products, apiError)
+	return products, resp, relevantError(err, apiError)
 }
 
 // Show returns the requested Product.

--- a/bigcommerce/products_test.go
+++ b/bigcommerce/products_test.go
@@ -20,7 +20,7 @@ func TestProductService_List(t *testing.T) {
 		fmt.Fprintf(w, `[{ "id": 123 }]`)
 	})
 
-	expected := &Products{
+	expected := []Product{
 		{ID: 123},
 	}
 	client := NewClient(httpClient, &ClientConfig{


### PR DESCRIPTION
Remove all types that are just slices of objects. They can be useful, but not as they are used right now, and then it clearly indicates that you get a slice back.

Main annoyance was that you were returning a pointer to a slice, which is unneeded (slices can be nil).

Return counts as int.