### PR TITLE
Use int and float64 throughout.

### DIFF
--- a/bigcommerce/order_shipping_addresses.go
+++ b/bigcommerce/order_shipping_addresses.go
@@ -11,8 +11,8 @@ import (
 // Order describes the product resource
 type OrderShippingAddress struct {
 	AddressEntity
-	ID      int32 `json:"id"`
-	OrderID int32 `json:"order_id"`
+	ID      int `json:"id"`
+	OrderID int `json:"order_id"`
 }
 
 // OrderShippingAddressService adds the APIs for the OrderShippingAddress resource.
@@ -30,12 +30,12 @@ func newOrderShippingAddressService(sling *sling.Sling, httpClient *http.Client)
 
 // OrderShippingAddressListParams are the parameters for OrderShippingAddressService.List
 type OrderShippingAddressListParams struct {
-	Page  int32 `url:"page,omitempty"`
-	Limit int32 `url:"limit,omitempty"`
+	Page  int `url:"page,omitempty"`
+	Limit int `url:"limit,omitempty"`
 }
 
 // List returns a list of OrderShippingAddresses matching the given OrderShippingAddressListParams.
-func (s *OrderShippingAddressService) List(ctx context.Context, orderID int32, params *OrderShippingAddressListParams) ([]OrderShippingAddress, *http.Response, error) {
+func (s *OrderShippingAddressService) List(ctx context.Context, orderID int, params *OrderShippingAddressListParams) ([]OrderShippingAddress, *http.Response, error) {
 	var osa []OrderShippingAddress
 	apiError := new(APIError)
 
@@ -44,7 +44,7 @@ func (s *OrderShippingAddressService) List(ctx context.Context, orderID int32, p
 }
 
 // Count returns an OrderShippingAddressCount for OrderShippingAddresses that matches the given OrderShippingAddressListParams.
-func (s *OrderShippingAddressService) Count(ctx context.Context, orderID int32, params *OrderShippingAddressListParams) (int, *http.Response, error) {
+func (s *OrderShippingAddressService) Count(ctx context.Context, orderID int, params *OrderShippingAddressListParams) (int, *http.Response, error) {
 	var cnt count
 	apiError := new(APIError)
 
@@ -53,7 +53,7 @@ func (s *OrderShippingAddressService) Count(ctx context.Context, orderID int32, 
 }
 
 // Show returns the requested OrderShippingAddress.
-func (s *OrderShippingAddressService) Show(ctx context.Context, orderID int32, id int32) (*OrderShippingAddress, *http.Response, error) {
+func (s *OrderShippingAddressService) Show(ctx context.Context, orderID int, id int) (*OrderShippingAddress, *http.Response, error) {
 	osa := new(OrderShippingAddress)
 	apiError := new(APIError)
 

--- a/bigcommerce/order_shipping_addresses_test.go
+++ b/bigcommerce/order_shipping_addresses_test.go
@@ -17,7 +17,7 @@ func TestOrderShippingAddressService_List(t *testing.T) {
 		assertMethod(t, "GET", r)
 		assertQuery(t, map[string]string{"page": "1"}, r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `[{ "id": 123 }]`)
+		fmt.Fprint(w, `[{ "id": 123 }]`)
 	})
 
 	expected := []OrderShippingAddress{
@@ -42,7 +42,7 @@ func TestOrderShippingAddressService_Show(t *testing.T) {
 	mux.HandleFunc("/api/v2/orders/12/shipping_addresses/3", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "id": 123 }`)
+		fmt.Fprint(w, `{ "id": 123 }`)
 	})
 
 	expected := &OrderShippingAddress{ID: 123}

--- a/bigcommerce/order_statuses.go
+++ b/bigcommerce/order_statuses.go
@@ -10,9 +10,9 @@ import (
 
 // OrderStatus describes the product resource
 type OrderStatus struct {
-	ID    int32  `json:"id"`
+	ID    int    `json:"id"`
 	Name  string `json:"name"`
-	Order int32  `json:"order"`
+	Order int    `json:"order"`
 }
 
 // OrderStatusService adds the APIs for the Product resource.
@@ -30,8 +30,8 @@ func newOrderStatusService(sling *sling.Sling, httpClient *http.Client) *OrderSt
 
 // OrderStatusListParams are the parameters for OrderStatusService.List
 type OrderStatusListParams struct {
-	Page  int32 `url:"page,omitempty"`
-	Limit int32 `url:"limit,omitempty"`
+	Page  int `url:"page,omitempty"`
+	Limit int `url:"limit,omitempty"`
 }
 
 // List returns a list of Products matching the given ProductListParams.
@@ -44,7 +44,7 @@ func (s *OrderStatusService) List(ctx context.Context, params *OrderStatusListPa
 }
 
 // Show returns the requested OrderStatus.
-func (s *OrderStatusService) Show(ctx context.Context, id int32) (*OrderStatus, *http.Response, error) {
+func (s *OrderStatusService) Show(ctx context.Context, id int) (*OrderStatus, *http.Response, error) {
 	orderStatus := new(OrderStatus)
 	apiError := new(APIError)
 

--- a/bigcommerce/order_statuses_test.go
+++ b/bigcommerce/order_statuses_test.go
@@ -17,7 +17,7 @@ func TestOrderStatusService_List(t *testing.T) {
 		assertMethod(t, "GET", r)
 		assertQuery(t, map[string]string{"limit": "1"}, r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `[{ "id": 123 }]`)
+		fmt.Fprint(w, `[{ "id": 123 }]`)
 	})
 
 	expected := []OrderStatus{
@@ -42,7 +42,7 @@ func TestOrderStatusService_Show(t *testing.T) {
 	mux.HandleFunc("/api/v2/order_statuses/1", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "id": 1 }`)
+		fmt.Fprint(w, `{ "id": 1 }`)
 	})
 
 	expected := &OrderStatus{ID: 1}

--- a/bigcommerce/orders.go
+++ b/bigcommerce/orders.go
@@ -5,42 +5,44 @@ import (
 	"fmt"
 	"net/http"
 
+	"time"
+
 	"github.com/dghubble/sling"
 )
 
 // Order describes the product resource
 type Order struct {
-	ID                   int32         `json:"id"`
-	CustomerID           int32         `json:"customer_id"`
-	DateCreated          string        `json:"date_created"`
-	DateModified         string        `json:"date_modified"`
-	DateShipped          string        `json:"date_shipped"`
-	StatusID             int32         `json:"status_id"`
+	ID                   int           `json:"id"`
+	CustomerID           int           `json:"customer_id"`
+	DateCreated          time.Time     `json:"date_created"`
+	DateModified         time.Time     `json:"date_modified"`
+	DateShipped          time.Time     `json:"date_shipped"`
+	StatusID             int           `json:"status_id"`
 	Status               string        `json:"status"`
-	HandlingCostExTax    string        `json:"handling_cost_ex_tax"`
-	HandlingCostIncTax   string        `json:"handling_cost_inc_tax"`
-	HandlingCostTax      string        `json:"handling_cost_tax"`
-	ShippingCostExTax    string        `json:"shipping_cost_ex_tax"`
-	ShippingCostIncTax   string        `json:"shipping_cost_inc_tax"`
-	ShippingCostTax      string        `json:"shipping_cost_tax"`
-	SubTotalExTax        string        `json:"subtotal_ex_tax"`
-	SubTotalIncTax       string        `json:"subtotal_inc_tax"`
-	SubTotalTax          string        `json:"subtotal_tax"`
-	TotalExTax           string        `json:"total_ex_tax"`
-	TotalIncTax          string        `json:"total_inc_tax"`
-	TotalTax             string        `json:"total_tax"`
-	BaseShippingCost     string        `json:"base_shipping_cost"`
-	ItemsTotal           int32         `json:"items_total"`
+	HandlingCostExTax    float64       `json:"handling_cost_ex_tax,string"`
+	HandlingCostIncTax   float64       `json:"handling_cost_inc_tax,string"`
+	HandlingCostTax      float64       `json:"handling_cost_tax,string"`
+	ShippingCostExTax    float64       `json:"shipping_cost_ex_tax,string"`
+	ShippingCostIncTax   float64       `json:"shipping_cost_inc_tax,string"`
+	ShippingCostTax      float64       `json:"shipping_cost_tax,string"`
+	SubTotalExTax        float64       `json:"subtotal_ex_tax,string"`
+	SubTotalIncTax       float64       `json:"subtotal_inc_tax,string"`
+	SubTotalTax          float64       `json:"subtotal_tax,string"`
+	TotalExTax           float64       `json:"total_ex_tax,string"`
+	TotalIncTax          float64       `json:"total_inc_tax,string"`
+	TotalTax             float64       `json:"total_tax,string"`
+	BaseShippingCost     float64       `json:"base_shipping_cost,string"`
+	ItemsTotal           int           `json:"items_total"`
 	PaymentMethod        string        `json:"payment_method"`
 	PaymentStatus        string        `json:"payment_status"`
 	IPAddress            string        `json:"ip_address"`
-	CurrencyID           int32         `json:"currency_id"`
+	CurrencyID           int           `json:"currency_id"`
 	CurrencyCode         string        `json:"currency_code"`
 	StaffNotes           string        `json:"staff_notes"`
 	CustomerMessage      string        `json:"customer_message"`
 	DiscountAmount       string        `json:"discount_amount"`
 	CouponDiscount       string        `json:"counpon_discount"`
-	ShippingAddressCount int32         `json:"shipping_address_count"`
+	ShippingAddressCount int           `json:"shipping_address_count"`
 	BillingAddress       AddressEntity `json:"billing_address"`
 }
 
@@ -59,16 +61,16 @@ func newOrderService(sling *sling.Sling, httpClient *http.Client) *OrderService 
 
 // OrderListParams are the parameters for OrderService.List
 type OrderListParams struct {
-	Page          int32   `url:"page,omitempty"`
-	Limit         int32   `url:"limit,omitempty"`
+	Page          int     `url:"page,omitempty"`
+	Limit         int     `url:"limit,omitempty"`
 	Sort          string  `url:"sort,omitempty"`
-	MinID         int32   `url:"min_id,omitempty"`
-	MaxID         int32   `url:"max_id,omitempty"`
-	MinTotal      float32 `url:"min_total,omitempty"`
-	MaxTotal      float32 `url:"max_total,omitempty"`
-	CustomerID    *uint32 `url:"customer_id,omitempty"`
+	MinID         int     `url:"min_id,omitempty"`
+	MaxID         int     `url:"max_id,omitempty"`
+	MinTotal      float64 `url:"min_total,omitempty"`
+	MaxTotal      float64 `url:"max_total,omitempty"`
+	CustomerID    *int    `url:"customer_id,omitempty"`
 	Email         string  `url:"email,omitempty"`
-	StatusID      *uint32 `url:"status_id,omitempty"`
+	StatusID      *int    `url:"status_id,omitempty"`
 	PaymentMethod string  `url:"payment_method,omitempty"`
 	//TODO: add date and boolean based params.
 }
@@ -104,27 +106,28 @@ func (s *OrderService) Show(ctx context.Context, id int32) (*Order, *http.Respon
 // Regular Products require: ProductID and Quantity
 // Custom Products require: Name, Quantity and PriceIncTax / PriceExTax
 type OrderProduct struct {
-	ProductID   int32   `json:"product_id,omitempty"`
+	ProductID   int     `json:"product_id,omitempty"`
 	ProductName string  `json:"name,omitempty"`
-	Quantity    int32   `json:"quantity"`
-	PriceIncTax float32 `json:"price_inc_tax,omitempty"`
-	PriceExTax  float32 `json:"price_ex_tax,omitempty"`
+	Quantity    int     `json:"quantity"`
+	PriceIncTax float64 `json:"price_inc_tax,omitempty"`
+	PriceExTax  float64 `json:"price_ex_tax,omitempty"`
 }
 
 // OrderBody describes the order information given when creating a new Order.
 type OrderBody struct {
 	ExternalSource     string          `json:"external_source"`
-	CustomerID         *uint32         `json:"customer_id"`
-	StatusID           *uint32         `json:"status_id"`
+	CustomerID         *int            `json:"customer_id"`
+	StatusID           *int            `json:"status_id"`
 	BillingAddress     AddressEntity   `json:"billing_address"`
 	Products           []OrderProduct  `json:"products"`
-	ShippingCostIncTax float32         `json:"shipping_cost_inc_tax,omitempty"`
-	ShippingCostExTax  float32         `json:"shipping_cost_ex_tax,omitempty"`
-	HandlingCostIncTax float32         `json:"handling_cost_inc_tax,omitempty"`
-	HandlingCostExTax  float32         `json:"handling_cost_ex_tax,omitempty"`
+	ShippingCostIncTax float64         `json:"shipping_cost_inc_tax,omitempty"`
+	ShippingCostExTax  float64         `json:"shipping_cost_ex_tax,omitempty"`
+	HandlingCostIncTax float64         `json:"handling_cost_inc_tax,omitempty"`
+	HandlingCostExTax  float64         `json:"handling_cost_ex_tax,omitempty"`
 	ShippingAddresses  AddressEntities `json:"shipping_addresses,omitempty"`
 	CustomerMessage    string          `json:"customer_message"`
 	StaffNotes         string          `json:"staff_notes"`
+	PaymentMethod      string          `json:"payment_method"`
 }
 
 // New creates a new Order with the specified information and returns the new order.
@@ -147,7 +150,7 @@ type OrderEditParams struct {
 }
 
 // Edit updates the given OrderEditParams of the given Order.
-func (s *OrderService) Edit(ctx context.Context, id int32, params *OrderEditParams) (*Order, *http.Response, error) {
+func (s *OrderService) Edit(ctx context.Context, id int, params *OrderEditParams) (*Order, *http.Response, error) {
 	order := new(Order)
 	apiError := new(APIError)
 

--- a/bigcommerce/orders_test.go
+++ b/bigcommerce/orders_test.go
@@ -17,7 +17,7 @@ func TestOrderService_List(t *testing.T) {
 		assertMethod(t, "GET", r)
 		assertQuery(t, map[string]string{"customer_id": "0"}, r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `[{ "id": 123 }]`)
+		fmt.Fprint(w, `[{ "id": 123 }]`)
 	})
 
 	expected := []Order{
@@ -27,7 +27,7 @@ func TestOrderService_List(t *testing.T) {
 		Endpoint: "https://example.com",
 		UserName: "go-bigcommerce",
 		Password: "12345"})
-	customerID := uint32(0)
+	customerID := 0
 	params := &OrderListParams{
 		CustomerID: &customerID,
 	}
@@ -44,7 +44,7 @@ func TestOrderService_Count(t *testing.T) {
 		assertMethod(t, "GET", r)
 		assertQuery(t, map[string]string{"customer_id": "0"}, r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "count": 12 }`)
+		fmt.Fprint(w, `{ "count": 12 }`)
 	})
 
 	expected := 12
@@ -52,7 +52,7 @@ func TestOrderService_Count(t *testing.T) {
 		Endpoint: "https://example.com",
 		UserName: "go-bigcommerce",
 		Password: "12345"})
-	customerID := uint32(0)
+	customerID := 0
 	params := &OrderListParams{
 		CustomerID: &customerID,
 	}
@@ -68,7 +68,7 @@ func TestOrderService_Show(t *testing.T) {
 	mux.HandleFunc("/api/v2/orders/123", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "id": 123 }`)
+		fmt.Fprint(w, `{ "id": 123 }`)
 	})
 
 	expected := &Order{ID: 123}
@@ -88,7 +88,7 @@ func TestOrderService_New(t *testing.T) {
 	mux.HandleFunc("/api/v2/orders/", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "POST", r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "id": 123 }`)
+		fmt.Fprint(w, `{ "id": 123 }`)
 	})
 
 	expected := &Order{ID: 123}
@@ -96,8 +96,8 @@ func TestOrderService_New(t *testing.T) {
 		Endpoint: "https://example.com",
 		UserName: "go-bigcommerce",
 		Password: "12345"})
-	customerID := uint32(10)
-	statusID := uint32(0)
+	customerID := 10
+	statusID := 0
 	body := &OrderBody{
 		ExternalSource: "test-suite",
 		CustomerID:     &customerID,

--- a/bigcommerce/product_custom_fields.go
+++ b/bigcommerce/product_custom_fields.go
@@ -10,8 +10,8 @@ import (
 
 // ProductCustomField describes the product custom field resource
 type ProductCustomField struct {
-	ID        int32  `json:"id"`
-	ProductID int32  `json:"product_id"`
+	ID        int    `json:"id"`
+	ProductID int    `json:"product_id"`
 	Name      string `json:"name"`
 	Text      string `json:"text"`
 }
@@ -31,12 +31,12 @@ func newProductCustomFieldService(sling *sling.Sling, httpClient *http.Client) *
 
 // ProductCustomFieldListParams are the parameters for ProductCustomFieldService.List
 type ProductCustomFieldListParams struct {
-	Page  int32 `url:"page,omitempty"`
-	Limit int32 `url:"limit,omitempty"`
+	Page  int `url:"page,omitempty"`
+	Limit int `url:"limit,omitempty"`
 }
 
 // List returns a list of ProductCustomFields matching the given ProductCustomFieldListParams.
-func (s *ProductCustomFieldService) List(ctx context.Context, productID int32, params *ProductCustomFieldListParams) ([]ProductCustomField, *http.Response, error) {
+func (s *ProductCustomFieldService) List(ctx context.Context, productID int, params *ProductCustomFieldListParams) ([]ProductCustomField, *http.Response, error) {
 	var customFields []ProductCustomField
 	apiError := new(APIError)
 
@@ -45,7 +45,7 @@ func (s *ProductCustomFieldService) List(ctx context.Context, productID int32, p
 }
 
 // Show returns the requested ProductCustomField.
-func (s *ProductCustomFieldService) Show(ctx context.Context, productID int32, id int32) (*ProductCustomField, *http.Response, error) {
+func (s *ProductCustomFieldService) Show(ctx context.Context, productID int, id int) (*ProductCustomField, *http.Response, error) {
 	customField := new(ProductCustomField)
 	apiError := new(APIError)
 

--- a/bigcommerce/product_custom_fields_test.go
+++ b/bigcommerce/product_custom_fields_test.go
@@ -17,7 +17,7 @@ func TestProductCustomFieldService_List(t *testing.T) {
 		assertMethod(t, "GET", r)
 		assertQuery(t, map[string]string{"page": "1"}, r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `[{ "id": 123 }]`)
+		fmt.Fprint(w, `[{ "id": 123 }]`)
 	})
 
 	expected := []ProductCustomField{
@@ -42,7 +42,7 @@ func TestProductCustomFieldService_Show(t *testing.T) {
 	mux.HandleFunc("/api/v2/products/12/custom_fields/3", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "id": 123 }`)
+		fmt.Fprint(w, `{ "id": 123 }`)
 	})
 
 	expected := &ProductCustomField{ID: 123}

--- a/bigcommerce/products.go
+++ b/bigcommerce/products.go
@@ -10,15 +10,15 @@ import (
 
 // Product describes the product resource
 type Product struct {
-	ID             int32              `json:"id"`
+	ID             int                `json:"id"`
 	Name           string             `json:"name"`
 	Sku            string             `json:"sku"`
 	Description    string             `json:"description"`
 	Price          string             `json:"price"`
 	CostPrice      string             `json:"cost_price"`
 	RetailPrice    string             `json:"retail_price"`
-	InventoryLevel int32              `json:"inventory_level"`
-	TotalSold      int32              `json:"total_sold"`
+	InventoryLevel int                `json:"inventory_level"`
+	TotalSold      int                `json:"total_sold"`
 	Availability   string             `json:"availability"`
 	PrimaryImage   PrimaryImageEntity `json:"primary_image"`
 }
@@ -46,15 +46,15 @@ func newProductService(sling *sling.Sling, httpClient *http.Client) *ProductServ
 
 // ProductListParams are the parameters for ProductService.List
 type ProductListParams struct {
-	MinID             int32  `url:"min_id,omitempty"`
-	MaxID             int32  `url:"max_id,omitempty"`
+	MinID             int    `url:"min_id,omitempty"`
+	MaxID             int    `url:"max_id,omitempty"`
 	Name              string `url:"name,omitempty"`
 	Sku               string `url:"sku,omitempty"`
 	Availability      string `url:"availability,omitempty"`
 	IsVisible         string `url:"is_visible,omitempty"`
 	IsFeatured        string `url:"is_featured,omitempty"`
-	MinInventoryLevel int32  `url:"min_inventory_level,omitempty"`
-	MaxInventoryLevel int32  `url:"max_inventory_level,omitempty"`
+	MinInventoryLevel int    `url:"min_inventory_level,omitempty"`
+	MaxInventoryLevel int    `url:"max_inventory_level,omitempty"`
 }
 
 // List returns a list of Products matching the given ProductListParams.

--- a/bigcommerce/products_test.go
+++ b/bigcommerce/products_test.go
@@ -17,7 +17,7 @@ func TestProductService_List(t *testing.T) {
 		assertMethod(t, "GET", r)
 		assertQuery(t, map[string]string{"sku": "VIV-300020"}, r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `[{ "id": 123 }]`)
+		fmt.Fprint(w, `[{ "id": 123 }]`)
 	})
 
 	expected := []Product{
@@ -42,7 +42,7 @@ func TestProductService_Show(t *testing.T) {
 	mux.HandleFunc("/api/v2/products/123", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{ "id": 123 }`)
+		fmt.Fprint(w, `{ "id": 123 }`)
 	})
 
 	expected := &Product{ID: 123}


### PR DESCRIPTION
This makes it possible to use the API with less type conversions.

Also changes a few fmt.Fprintf without formatting to fmt.Fprint