### PR TITLE
Add Custom Date Types

### DIFF
--- a/bigcommerce/entities.go
+++ b/bigcommerce/entities.go
@@ -1,5 +1,10 @@
 package bigcommerce
 
+import (
+	"strconv"
+	"time"
+)
+
 // count is a generic object used for returning resource counts.
 type count struct {
 	Count int `json:"count"`
@@ -22,4 +27,47 @@ type AddressEntity struct {
 	CountryIso2 string `json:"country_iso2"`
 	Phone       string `json:"phone"`
 	Email       string `json:"email"`
+}
+
+// BCTime converts to/from Big Commerce Time format (RFC1123).
+// BC returns "" to indicate unset (null) values.
+// The internal time will be nil in those cases.
+type BCTime struct {
+	t *time.Time
+}
+
+// NewBCTime returns a wrapped time.
+// The supplied time can be nil.
+func NewBCTime(t *time.Time) BCTime {
+	return BCTime{t: t}
+}
+
+// Time returns the wrapped time.
+func (b BCTime) Time() *time.Time {
+	return b.t
+}
+
+func (b *BCTime) UnmarshalJSON(text []byte) error {
+	s, err := strconv.Unquote(string(text))
+	if err != nil {
+		return err
+	}
+	// In BC an empty string is null.
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC1123Z, s)
+	if err != nil {
+		return err
+	}
+	*b = BCTime{t: &t}
+	return nil
+}
+
+func (b BCTime) MarshalJSON() (text []byte, err error) {
+	if b.t == nil || b.t.IsZero() {
+		return []byte(`""`), nil
+	}
+	s := b.t.Format(time.RFC1123Z)
+	return []byte(strconv.Quote(s)), nil
 }

--- a/bigcommerce/orders.go
+++ b/bigcommerce/orders.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"time"
-
 	"github.com/dghubble/sling"
 )
 
@@ -14,9 +12,9 @@ import (
 type Order struct {
 	ID                   int           `json:"id"`
 	CustomerID           int           `json:"customer_id"`
-	DateCreated          time.Time     `json:"date_created"`
-	DateModified         time.Time     `json:"date_modified"`
-	DateShipped          time.Time     `json:"date_shipped"`
+	DateCreated          BCTime        `json:"date_created"`
+	DateModified         BCTime        `json:"date_modified"`
+	DateShipped          BCTime        `json:"date_shipped"`
 	StatusID             int           `json:"status_id"`
 	Status               string        `json:"status"`
 	HandlingCostExTax    float64       `json:"handling_cost_ex_tax,string"`


### PR DESCRIPTION
BCTime converts to/from Big Commerce Time format (RFC1123).
BC returns "" to indicate unset (null) values, the internal time will be nil in those cases.