### PR TITLE
Refactor(bigcommerce): replace sling dependency with net/http usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ script:
  - go test -v ./...
 
 go:
-  - 1.7.x
-  - 1.8.x
+  - 1.9.x
+  - 1.10.x
   - master

--- a/bigcommerce/bigcommerce_test.go
+++ b/bigcommerce/bigcommerce_test.go
@@ -12,6 +12,9 @@ import (
 
 var defaultTestTimeout = time.Second * 1
 
+const BadRequestJSON = `[{ "status": 400, "message": "Bad Request" }]`
+const BadRequestErrorMessage = "bigcommerce: 400 Bad Request"
+
 // testServer returns an http Client, ServeMux, and Server. The client proxies
 // requests to the server and handlers can be registered on the mux to handle
 // requests. The caller must close the test server.

--- a/bigcommerce/entities.go
+++ b/bigcommerce/entities.go
@@ -48,6 +48,7 @@ func (b BCTime) Time() *time.Time {
 	return b.t
 }
 
+// UnmarshalJSON decodes the json bytes and set the BCTime accordingly.
 func (b *BCTime) UnmarshalJSON(text []byte) error {
 	s, err := strconv.Unquote(string(text))
 	if err != nil {
@@ -65,6 +66,7 @@ func (b *BCTime) UnmarshalJSON(text []byte) error {
 	return nil
 }
 
+// MarshalJSON returns the JSON byte representation of BCTime.
 func (b BCTime) MarshalJSON() (text []byte, err error) {
 	if b.t == nil || b.t.IsZero() {
 		return []byte(`""`), nil

--- a/bigcommerce/order_shipping_addresses.go
+++ b/bigcommerce/order_shipping_addresses.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/dghubble/sling"
+	"strings"
 )
 
-// Order describes the product resource
+// OrderShippingAddress describes how shipping addresses are returned for an order.
+// It contains an ID, OrderID and an AddressEntity.
 type OrderShippingAddress struct {
 	AddressEntity
 	ID      int `json:"id"`
@@ -17,13 +17,13 @@ type OrderShippingAddress struct {
 
 // OrderShippingAddressService adds the APIs for the OrderShippingAddress resource.
 type OrderShippingAddressService struct {
-	sling      *sling.Sling
+	config     *ClientConfig
 	httpClient *http.Client
 }
 
-func newOrderShippingAddressService(sling *sling.Sling, httpClient *http.Client) *OrderShippingAddressService {
+func newOrderShippingAddressService(config *ClientConfig, httpClient *http.Client) *OrderShippingAddressService {
 	return &OrderShippingAddressService{
-		sling:      sling.Path("orders/"),
+		config:     config,
 		httpClient: httpClient,
 	}
 }
@@ -39,8 +39,9 @@ func (s *OrderShippingAddressService) List(ctx context.Context, orderID int, par
 	var osa []OrderShippingAddress
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses", orderID)).QueryStruct(params), s.httpClient, &osa, apiError)
-	return osa, resp, relevantError(err, *apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, s.servicePath(orderID), params, &osa, apiError)
+
+	return osa, response, relevantError(err, *apiError)
 }
 
 // Count returns an OrderShippingAddressCount for OrderShippingAddresses that matches the given OrderShippingAddressListParams.
@@ -48,8 +49,10 @@ func (s *OrderShippingAddressService) Count(ctx context.Context, orderID int, pa
 	var cnt count
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses/count", orderID)).QueryStruct(params), s.httpClient, &cnt, apiError)
-	return cnt.Count, resp, relevantError(err, *apiError)
+	path := strings.Join([]string{s.servicePath(orderID), "count"}, "")
+	response, err := performGET(ctx, s.httpClient, s.config, path, params, &cnt, apiError)
+
+	return cnt.Count, response, relevantError(err, *apiError)
 }
 
 // Show returns the requested OrderShippingAddress.
@@ -57,6 +60,12 @@ func (s *OrderShippingAddressService) Show(ctx context.Context, orderID int, id 
 	osa := new(OrderShippingAddress)
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/shipping_addresses/%d", orderID, id)), s.httpClient, osa, apiError)
-	return osa, resp, relevantError(err, *apiError)
+	path := fmt.Sprintf("%v%v", s.servicePath(orderID), id)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &osa, apiError)
+
+	return osa, response, relevantError(err, *apiError)
+}
+
+func (s *OrderShippingAddressService) servicePath(orderID int) string {
+	return fmt.Sprintf("orders/%d/shipping_addresses/", orderID)
 }

--- a/bigcommerce/order_shipping_addresses.go
+++ b/bigcommerce/order_shipping_addresses.go
@@ -37,33 +37,33 @@ type OrderShippingAddressListParams struct {
 // List returns a list of OrderShippingAddresses matching the given OrderShippingAddressListParams.
 func (s *OrderShippingAddressService) List(ctx context.Context, orderID int, params *OrderShippingAddressListParams) ([]OrderShippingAddress, *http.Response, error) {
 	var osa []OrderShippingAddress
-	apiError := new(APIError)
+	var apiError APIError
 
-	response, err := performGET(ctx, s.httpClient, s.config, s.servicePath(orderID), params, &osa, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, s.servicePath(orderID), params, &osa, &apiError)
 
-	return osa, response, relevantError(err, *apiError)
+	return osa, response, relevantError(err, apiError)
 }
 
 // Count returns an OrderShippingAddressCount for OrderShippingAddresses that matches the given OrderShippingAddressListParams.
 func (s *OrderShippingAddressService) Count(ctx context.Context, orderID int, params *OrderShippingAddressListParams) (int, *http.Response, error) {
 	var cnt count
-	apiError := new(APIError)
+	var apiError APIError
 
 	path := strings.Join([]string{s.servicePath(orderID), "count"}, "")
-	response, err := performGET(ctx, s.httpClient, s.config, path, params, &cnt, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, path, params, &cnt, &apiError)
 
-	return cnt.Count, response, relevantError(err, *apiError)
+	return cnt.Count, response, relevantError(err, apiError)
 }
 
 // Show returns the requested OrderShippingAddress.
 func (s *OrderShippingAddressService) Show(ctx context.Context, orderID int, id int) (*OrderShippingAddress, *http.Response, error) {
 	osa := new(OrderShippingAddress)
-	apiError := new(APIError)
+	var apiError APIError
 
 	path := fmt.Sprintf("%v%v", s.servicePath(orderID), id)
-	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &osa, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &osa, &apiError)
 
-	return osa, response, relevantError(err, *apiError)
+	return osa, response, relevantError(err, apiError)
 }
 
 func (s *OrderShippingAddressService) servicePath(orderID int) string {

--- a/bigcommerce/order_shipping_addresses_test.go
+++ b/bigcommerce/order_shipping_addresses_test.go
@@ -35,6 +35,30 @@ func TestOrderShippingAddressService_List(t *testing.T) {
 	assert.Equal(t, expected, orderShippingAddresses)
 }
 
+func TestOrderShippingAddressService_ListWithError(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/v2/orders/12/shipping_addresses/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"page": "1"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, BadRequestJSON)
+	})
+
+	client := NewClient(httpClient, &ClientConfig{
+		Endpoint: "https://example.com",
+		UserName: "go-bigcommerce",
+		Password: "12345"})
+	params := &OrderShippingAddressListParams{
+		Page: 1,
+	}
+	orderShippingAddresses, _, err := client.OrderShippingAddresses.List(context.Background(), 12, params)
+	assert.EqualError(t, err, BadRequestErrorMessage)
+	assert.True(t, len(orderShippingAddresses) == 0)
+}
+
 func TestOrderShippingAddressService_Count(t *testing.T) {
 	httpClient, mux, server := testServer()
 	defer server.Close()
@@ -61,6 +85,30 @@ func TestOrderShippingAddressService_Count(t *testing.T) {
 	assert.Equal(t, expected, count)
 }
 
+func TestOrderShippingAddressService_CountWithError(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/v2/orders/123/shipping_addresses/count", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"limit": "10"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, BadRequestJSON)
+	})
+
+	client := NewClient(httpClient, &ClientConfig{
+		Endpoint: "https://example.com",
+		UserName: "go-bigcommerce",
+		Password: "12345"})
+	params := &OrderShippingAddressListParams{
+		Limit: 10,
+	}
+	orderID := 123
+	_, _, err := client.OrderShippingAddresses.Count(context.Background(), orderID, params)
+	assert.EqualError(t, err, BadRequestErrorMessage)
+}
+
 func TestOrderShippingAddressService_Show(t *testing.T) {
 	httpClient, mux, server := testServer()
 	defer server.Close()
@@ -79,4 +127,23 @@ func TestOrderShippingAddressService_Show(t *testing.T) {
 	orderShippingAddress, _, err := client.OrderShippingAddresses.Show(context.Background(), 12, 3)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, orderShippingAddress)
+}
+
+func TestOrderShippingAddressService_ShowWithError(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/v2/orders/12/shipping_addresses/3", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, BadRequestJSON)
+	})
+
+	client := NewClient(httpClient, &ClientConfig{
+		Endpoint: "https://example.com",
+		UserName: "go-bigcommerce",
+		Password: "12345"})
+	_, _, err := client.OrderShippingAddresses.Show(context.Background(), 12, 3)
+	assert.EqualError(t, err, BadRequestErrorMessage)
 }

--- a/bigcommerce/order_shipping_addresses_test.go
+++ b/bigcommerce/order_shipping_addresses_test.go
@@ -13,7 +13,7 @@ func TestOrderShippingAddressService_List(t *testing.T) {
 	httpClient, mux, server := testServer()
 	defer server.Close()
 
-	mux.HandleFunc("/api/v2/orders/12/shipping_addresses", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v2/orders/12/shipping_addresses/", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		assertQuery(t, map[string]string{"page": "1"}, r)
 		w.Header().Set("Content-Type", "application/json")
@@ -33,6 +33,32 @@ func TestOrderShippingAddressService_List(t *testing.T) {
 	orderShippingAddresses, _, err := client.OrderShippingAddresses.List(context.Background(), 12, params)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, orderShippingAddresses)
+}
+
+func TestOrderShippingAddressService_Count(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/v2/orders/123/shipping_addresses/count", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"limit": "10"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{ "count": 12 }`)
+	})
+
+	expected := 12
+
+	client := NewClient(httpClient, &ClientConfig{
+		Endpoint: "https://example.com",
+		UserName: "go-bigcommerce",
+		Password: "12345"})
+	params := &OrderShippingAddressListParams{
+		Limit: 10,
+	}
+	orderID := 123
+	count, _, err := client.OrderShippingAddresses.Count(context.Background(), orderID, params)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, count)
 }
 
 func TestOrderShippingAddressService_Show(t *testing.T) {

--- a/bigcommerce/order_statuses.go
+++ b/bigcommerce/order_statuses.go
@@ -37,20 +37,20 @@ type OrderStatusListParams struct {
 // List returns a list of Products matching the given ProductListParams.
 func (s *OrderStatusService) List(ctx context.Context, params *OrderStatusListParams) ([]OrderStatus, *http.Response, error) {
 	var os []OrderStatus
-	apiError := new(APIError)
+	var apiError APIError
 
-	response, err := performGET(ctx, s.httpClient, s.config, orderStatusServicePath, params, &os, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, orderStatusServicePath, params, &os, &apiError)
 
-	return os, response, relevantError(err, *apiError)
+	return os, response, relevantError(err, apiError)
 }
 
 // Show returns the requested OrderStatus.
 func (s *OrderStatusService) Show(ctx context.Context, id int) (*OrderStatus, *http.Response, error) {
 	orderStatus := new(OrderStatus)
-	apiError := new(APIError)
+	var apiError APIError
 
 	path := fmt.Sprintf("%v%v", orderStatusServicePath, id)
-	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &orderStatus, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &orderStatus, &apiError)
 
-	return orderStatus, response, relevantError(err, *apiError)
+	return orderStatus, response, relevantError(err, apiError)
 }

--- a/bigcommerce/order_statuses.go
+++ b/bigcommerce/order_statuses.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/dghubble/sling"
 )
+
+const orderStatusServicePath = "order_statuses/"
 
 // OrderStatus describes the product resource
 type OrderStatus struct {
@@ -17,13 +17,13 @@ type OrderStatus struct {
 
 // OrderStatusService adds the APIs for the Product resource.
 type OrderStatusService struct {
-	sling      *sling.Sling
+	config     *ClientConfig
 	httpClient *http.Client
 }
 
-func newOrderStatusService(sling *sling.Sling, httpClient *http.Client) *OrderStatusService {
+func newOrderStatusService(config *ClientConfig, httpClient *http.Client) *OrderStatusService {
 	return &OrderStatusService{
-		sling:      sling.Path("order_statuses/"),
+		config:     config,
 		httpClient: httpClient,
 	}
 }
@@ -39,8 +39,9 @@ func (s *OrderStatusService) List(ctx context.Context, params *OrderStatusListPa
 	var os []OrderStatus
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().QueryStruct(params), s.httpClient, &os, apiError)
-	return os, resp, relevantError(err, *apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, orderStatusServicePath, params, &os, apiError)
+
+	return os, response, relevantError(err, *apiError)
 }
 
 // Show returns the requested OrderStatus.
@@ -48,6 +49,8 @@ func (s *OrderStatusService) Show(ctx context.Context, id int) (*OrderStatus, *h
 	orderStatus := new(OrderStatus)
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d", id)), s.httpClient, orderStatus, apiError)
-	return orderStatus, resp, relevantError(err, *apiError)
+	path := fmt.Sprintf("%v%v", orderStatusServicePath, id)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &orderStatus, apiError)
+
+	return orderStatus, response, relevantError(err, *apiError)
 }

--- a/bigcommerce/orders.go
+++ b/bigcommerce/orders.go
@@ -77,31 +77,31 @@ type OrderListParams struct {
 // List returns a list of Orders matching the given OrderListParams.
 func (s *OrderService) List(ctx context.Context, params *OrderListParams) ([]Order, *http.Response, error) {
 	var orders []Order
-	apiError := new(APIError)
-	response, err := performGET(ctx, s.httpClient, s.config, orderServicePath, params, &orders, apiError)
-	return orders, response, relevantError(err, *apiError)
+	var apiError APIError
+	response, err := performGET(ctx, s.httpClient, s.config, orderServicePath, params, &orders, &apiError)
+	return orders, response, relevantError(err, apiError)
 }
 
 // Count returns an OrderCount for Orders that matches the given OrderListParams.
 func (s *OrderService) Count(ctx context.Context, params *OrderListParams) (int, *http.Response, error) {
 	var cnt count
-	apiError := new(APIError)
+	var apiError APIError
 
 	path := strings.Join([]string{orderServicePath, "count"}, "")
-	response, err := performGET(ctx, s.httpClient, s.config, path, params, &cnt, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, path, params, &cnt, &apiError)
 
-	return cnt.Count, response, relevantError(err, *apiError)
+	return cnt.Count, response, relevantError(err, apiError)
 }
 
 // Show returns the requested Order.
 func (s *OrderService) Show(ctx context.Context, id int32) (*Order, *http.Response, error) {
 	order := new(Order)
-	apiError := new(APIError)
+	var apiError APIError
 
 	path := fmt.Sprintf("%v%v", orderServicePath, id)
-	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &order, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &order, &apiError)
 
-	return order, response, relevantError(err, *apiError)
+	return order, response, relevantError(err, apiError)
 }
 
 // OrderProduct defines a product to be included in the OrderBody.
@@ -140,11 +140,11 @@ type OrderBody struct {
 // New creates a new Order with the specified information and returns the new order.
 func (s *OrderService) New(ctx context.Context, body *OrderBody) (*Order, *http.Response, error) {
 	order := new(Order)
-	apiError := new(APIError)
+	var apiError APIError
 
-	response, err := performPOST(ctx, s.httpClient, s.config, orderServicePath, nil, body, order, apiError)
+	response, err := performPOST(ctx, s.httpClient, s.config, orderServicePath, nil, body, order, &apiError)
 
-	return order, response, relevantError(err, *apiError)
+	return order, response, relevantError(err, apiError)
 }
 
 // OrderEditParams describes the fields that are editable on an Order.
@@ -160,10 +160,10 @@ type OrderEditParams struct {
 // Edit updates the given OrderEditParams of the given Order.
 func (s *OrderService) Edit(ctx context.Context, id int, body *OrderEditParams) (*Order, *http.Response, error) {
 	order := new(Order)
-	apiError := new(APIError)
+	var apiError APIError
 
 	path := fmt.Sprintf("%v%v", orderServicePath, id)
-	response, err := performPUT(ctx, s.httpClient, s.config, path, nil, body, order, apiError)
+	response, err := performPUT(ctx, s.httpClient, s.config, path, nil, body, order, &apiError)
 
-	return order, response, relevantError(err, *apiError)
+	return order, response, relevantError(err, apiError)
 }

--- a/bigcommerce/product_custom_fields.go
+++ b/bigcommerce/product_custom_fields.go
@@ -37,22 +37,22 @@ type ProductCustomFieldListParams struct {
 // List returns a list of ProductCustomFields matching the given ProductCustomFieldListParams.
 func (s *ProductCustomFieldService) List(ctx context.Context, productID int, params *ProductCustomFieldListParams) ([]ProductCustomField, *http.Response, error) {
 	var customFields []ProductCustomField
-	apiError := new(APIError)
+	var apiError APIError
 
-	response, err := performGET(ctx, s.httpClient, s.config, s.servicePath(productID), params, &customFields, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, s.servicePath(productID), params, &customFields, &apiError)
 
-	return customFields, response, relevantError(err, *apiError)
+	return customFields, response, relevantError(err, apiError)
 }
 
 // Show returns the requested ProductCustomField.
 func (s *ProductCustomFieldService) Show(ctx context.Context, productID int, id int) (*ProductCustomField, *http.Response, error) {
 	customField := new(ProductCustomField)
-	apiError := new(APIError)
+	var apiError APIError
 
 	path := fmt.Sprintf("%v/%d", s.servicePath(productID), id)
-	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &customField, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &customField, &apiError)
 
-	return customField, response, relevantError(err, *apiError)
+	return customField, response, relevantError(err, apiError)
 }
 
 func (s *ProductCustomFieldService) servicePath(productID int) string {

--- a/bigcommerce/product_custom_fields.go
+++ b/bigcommerce/product_custom_fields.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dghubble/sling"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // ProductCustomField describes the product custom field resource
@@ -18,13 +17,13 @@ type ProductCustomField struct {
 
 // ProductCustomFieldService adds the APIs for the ProductCustomField resource.
 type ProductCustomFieldService struct {
-	sling      *sling.Sling
+	config     *ClientConfig
 	httpClient *http.Client
 }
 
-func newProductCustomFieldService(sling *sling.Sling, httpClient *http.Client) *ProductCustomFieldService {
+func newProductCustomFieldService(config *ClientConfig, httpClient *http.Client) *ProductCustomFieldService {
 	return &ProductCustomFieldService{
-		sling:      sling.Path("products/"),
+		config:     config,
 		httpClient: httpClient,
 	}
 }
@@ -40,8 +39,9 @@ func (s *ProductCustomFieldService) List(ctx context.Context, productID int, par
 	var customFields []ProductCustomField
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/custom_fields", productID)).QueryStruct(params), s.httpClient, &customFields, apiError)
-	return customFields, resp, relevantError(err, *apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, s.servicePath(productID), params, &customFields, apiError)
+
+	return customFields, response, relevantError(err, *apiError)
 }
 
 // Show returns the requested ProductCustomField.
@@ -49,6 +49,12 @@ func (s *ProductCustomFieldService) Show(ctx context.Context, productID int, id 
 	customField := new(ProductCustomField)
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d/custom_fields/%d", productID, id)), s.httpClient, customField, apiError)
-	return customField, resp, relevantError(err, *apiError)
+	path := fmt.Sprintf("%v/%d", s.servicePath(productID), id)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &customField, apiError)
+
+	return customField, response, relevantError(err, *apiError)
+}
+
+func (s *ProductCustomFieldService) servicePath(productID int) string {
+	return fmt.Sprintf("products/%d/custom_fields", productID)
 }

--- a/bigcommerce/product_custom_fields_test.go
+++ b/bigcommerce/product_custom_fields_test.go
@@ -35,6 +35,29 @@ func TestProductCustomFieldService_List(t *testing.T) {
 	assert.Equal(t, expected, customFields)
 }
 
+func TestProductCustomFieldService_ListWithError(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/v2/products/12/custom_fields", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		assertQuery(t, map[string]string{"page": "1"}, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, BadRequestJSON)
+	})
+	client := NewClient(httpClient, &ClientConfig{
+		Endpoint: "https://example.com",
+		UserName: "go-bigcommerce",
+		Password: "12345"})
+	params := &ProductCustomFieldListParams{
+		Page: 1,
+	}
+	customFields, _, err := client.ProductCustomFields.List(context.Background(), 12, params)
+	assert.EqualError(t, err, "bigcommerce: 400 Bad Request")
+	assert.True(t, len(customFields) == 0)
+}
+
 func TestProductCustomFieldService_Show(t *testing.T) {
 	httpClient, mux, server := testServer()
 	defer server.Close()
@@ -53,4 +76,22 @@ func TestProductCustomFieldService_Show(t *testing.T) {
 	customField, _, err := client.ProductCustomFields.Show(context.Background(), 12, 3)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, customField)
+}
+
+func TestProductCustomFieldService_ShowWithError(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/v2/products/12/custom_fields/3", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, BadRequestJSON)
+	})
+	client := NewClient(httpClient, &ClientConfig{
+		Endpoint: "https://example.com",
+		UserName: "go-bigcommerce",
+		Password: "12345"})
+	_, _, err := client.ProductCustomFields.Show(context.Background(), 12, 3)
+	assert.EqualError(t, err, "bigcommerce: 400 Bad Request")
 }

--- a/bigcommerce/products.go
+++ b/bigcommerce/products.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dghubble/sling"
-	"golang.org/x/net/context"
+	"context"
 )
+
+const productServicePath = "products/"
 
 // Product describes the product resource
 type Product struct {
@@ -33,13 +34,13 @@ type PrimaryImageEntity struct {
 
 // ProductService adds the APIs for the Product resource.
 type ProductService struct {
-	sling      *sling.Sling
+	config     *ClientConfig
 	httpClient *http.Client
 }
 
-func newProductService(sling *sling.Sling, httpClient *http.Client) *ProductService {
+func newProductService(config *ClientConfig, httpClient *http.Client) *ProductService {
 	return &ProductService{
-		sling:      sling.Path("products/"),
+		config:     config,
 		httpClient: httpClient,
 	}
 }
@@ -62,8 +63,9 @@ func (s *ProductService) List(ctx context.Context, params *ProductListParams) ([
 	var products []Product
 	var apiError APIError
 
-	resp, err := performRequest(ctx, s.sling.New().QueryStruct(params), s.httpClient, &products, apiError) //.Receive(products, apiError)
-	return products, resp, relevantError(err, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, productServicePath, params, &products, apiError)
+
+	return products, response, relevantError(err, apiError)
 }
 
 // Show returns the requested Product.
@@ -71,6 +73,8 @@ func (s *ProductService) Show(ctx context.Context, id int32) (*Product, *http.Re
 	product := new(Product)
 	apiError := new(APIError)
 
-	resp, err := performRequest(ctx, s.sling.New().Get(fmt.Sprintf("%d", id)), s.httpClient, product, apiError)
-	return product, resp, relevantError(err, *apiError)
+	path := fmt.Sprintf("%v%v", productServicePath, id)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &product, apiError)
+
+	return product, response, relevantError(err, *apiError)
 }

--- a/bigcommerce/products.go
+++ b/bigcommerce/products.go
@@ -61,20 +61,20 @@ type ProductListParams struct {
 // List returns a list of Products matching the given ProductListParams.
 func (s *ProductService) List(ctx context.Context, params *ProductListParams) ([]Product, *http.Response, error) {
 	var products []Product
-	apiError := new(APIError)
+	var apiError APIError
 
-	response, err := performGET(ctx, s.httpClient, s.config, productServicePath, params, &products, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, productServicePath, params, &products, &apiError)
 
-	return products, response, relevantError(err, *apiError)
+	return products, response, relevantError(err, apiError)
 }
 
 // Show returns the requested Product.
 func (s *ProductService) Show(ctx context.Context, id int32) (*Product, *http.Response, error) {
 	product := new(Product)
-	apiError := new(APIError)
+	var apiError APIError
 
 	path := fmt.Sprintf("%v%v", productServicePath, id)
-	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &product, apiError)
+	response, err := performGET(ctx, s.httpClient, s.config, path, nil, &product, &apiError)
 
-	return product, response, relevantError(err, *apiError)
+	return product, response, relevantError(err, apiError)
 }


### PR DESCRIPTION
1) refactor(bigcommerce): drop dependency on the `github.com/dghubble/sling`, `golang.org/x/net/context` and `golang.org/x/net/context/ctxhttp` packages. Instead simply use `net/http`.
2) chore(travis): update config with newer go-versions